### PR TITLE
Task/Display-only-4-digits-on-card-item

### DIFF
--- a/src/pages/Account/MyCards.tsx
+++ b/src/pages/Account/MyCards.tsx
@@ -20,7 +20,7 @@ import {
   IonTitle,
   IonToolbar,
 } from "@ionic/react";
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 import { CardImages } from "../../constants";
 import { CardItemType } from "@/types/payment.types";
@@ -29,6 +29,7 @@ import { chevronForwardOutline } from "ionicons/icons";
 
 interface CardItemComponentType extends CardItemType {
   onClick?: React.MouseEventHandler<HTMLIonItemElement>;
+  show?: boolean;
 }
 
 export function CardItem(props: CardItemComponentType) {
@@ -44,6 +45,10 @@ export function CardItem(props: CardItemComponentType) {
     }
   };
 
+  const formattedCardNumber = Payment.fns.formatCardNumber(props.cardNumber);
+  const lastFourDigits = formattedCardNumber.split(' ').toReversed()[0];
+  const hiddenCardNumber = `${'**** '.repeat(3)} ${lastFourDigits}`;
+
   return (
     <IonItem {...additionalProps()}>
       <IonLabel
@@ -54,7 +59,7 @@ export function CardItem(props: CardItemComponentType) {
           style={{ display: "flex", flexDirection: "column" }}
           className="ion-text-start ion-justify-content-center"
         >
-          <h1>{Payment.fns.formatCardNumber(props.cardNumber)}</h1>
+          <h1>{props.show ? formattedCardNumber : hiddenCardNumber}</h1>
           <IonText>{props.cardHolder}</IonText>
         </div>
         <div>

--- a/src/pages/Account/MyCards.tsx
+++ b/src/pages/Account/MyCards.tsx
@@ -45,9 +45,17 @@ export function CardItem(props: CardItemComponentType) {
     }
   };
 
-  const formattedCardNumber = Payment.fns.formatCardNumber(props.cardNumber);
-  const lastFourDigits = formattedCardNumber.split(' ').toReversed()[0];
-  const hiddenCardNumber = `${'**** '.repeat(3)} ${lastFourDigits}`;
+  const formattedNumbers = Payment.fns.formatCardNumber(props.cardNumber);
+  const parts = formattedNumbers.split(' ');
+
+  // Mask all but the last group, preserving group lengths
+  const masked = parts
+    .map((part, idx) =>
+      idx === parts.length - 1 ? part : '*'.repeat(part.length)
+    )
+    .join(' ');
+
+  const partiallyShownNumbers = masked;
 
   return (
     <IonItem {...additionalProps()}>
@@ -59,7 +67,7 @@ export function CardItem(props: CardItemComponentType) {
           style={{ display: "flex", flexDirection: "column" }}
           className="ion-text-start ion-justify-content-center"
         >
-          <h1>{props.show ? formattedCardNumber : hiddenCardNumber}</h1>
+          <h1>{props.show ? formattedNumbers : partiallyShownNumbers}</h1>
           <IonText>{props.cardHolder}</IonText>
         </div>
         <div>


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a summary of your changes in the title and details below.
  This template helps reviewers understand your PR quickly and thoroughly.
-->

## ✅ Type of Change

<!-- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature
- [x] ✨ Change Request (UI or behavior update)
- [ ] 🛠️ Bug fix
- [ ] ❌ Breaking change
- [ ] 🧹 Code refactor
- [ ] ✅ Build config change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

---

## 📝 Description

<!-- 
Describe what this PR does and why.
Keep it short but informative.
-->
Only show the last 4 digits of a card.

## 🎯 Scope

<!-- 
Explain what feature, bug, or component this PR touches and the reason for the change.
-->
CardItem

## 🔧 Implementation

<!-- 
Briefly describe how the changes were implemented.
Mention if you had to refactor code, create new files, or introduce new patterns.
Include any trade-offs or decisions made.
-->
Card number formatted by Payments package was stored inside of `formattedCardNumber`. The last four digits is stored in `lastFourDigits`. Then a variable was created to concatinate a sequence of asterisks and the last four digits, to serve as the display value.

Additionally a prop `show` was added to conditionally display the whole card number. 

## 🧪 How to Test

<!-- 
List reproducible steps for manually testing this PR.
Example:
1. Navigate to `/notifications`
2. Tap the bell icon
3. Confirm unread notifications are displayed
-->
1. Navigate to Profile tab.
2. Tap on "Bank Accounts / Cards."
3. Confirm that the card numbers are redacted with *, except the last 4 digits.

## 👥 Co-Implemented With

<!-- 
Use this to credit collaborators on this PR.
Mention GitHub usernames.
Example:
Implemented with @username
-->
Implemented with @

## 📎 Related Issue

<!-- 
Link to the issue this PR addresses.
Use GitHub keywords to auto-close issues.
Example:
Fixes #123
-->
Fixes #5 

---

## 📸 Screenshots

<!-- 
Include screenshots comparing the UI before and after.
Use GitHub image uploads or drag-and-drop directly here.
Leave blank if not applicable.
-->

| Component       | Before | After |
|--------------|--------|-------|
| CardItem | ![Screenshot From 2025-05-10 13-09-19](https://github.com/user-attachments/assets/593ff150-3184-4c5d-8c83-50a66e356052) | ![Screenshot From 2025-05-11 16-16-48](https://github.com/user-attachments/assets/7e4d4457-69de-44d4-bc36-2a092715c0a9) |

---