### PR TITLE
Task/fix imports refactor hook names

### DIFF
--- a/src/pages/Category.tsx
+++ b/src/pages/Category.tsx
@@ -23,7 +23,7 @@ import { categoryAtom } from "../atoms/products";
 import { useCollectionDataOnce } from "react-firebase-hooks/firestore";
 import { useLocation } from "react-router";
 import { useRecoilValue } from "recoil";
-import { useRefresh } from "../hooks/useRefresh";
+import useRefresh from "@/hooks/useRefresh";
 
 export default function CategoryPage() {
   const categoryState = useRecoilValue(categoryAtom);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -28,7 +28,7 @@ import { FirebaseError } from "firebase/app";
 import Logo2 from "../assets/The Coffee Lounge - Logo 2.svg";
 import { logInOutline } from "ionicons/icons";
 import { nextUrl } from "../App";
-import { useColorScheme } from "../hooks/useRefresh";
+import useColorScheme from "@/hooks/useColorScheme";
 import { useHistory } from "react-router";
 
 interface IFormInput {


### PR DESCRIPTION
# 🛠️ Fix Imports of Refactor hook names

## Explain why refactoring is needed.
<!-- 
Hint: Explain the reasoning behind this refactor. 
Examples: Improve maintainability, fix performance bottlenecks, enforce coding standards, etc. 
-->
- To enforce React naming conventions, all hook filenames should follow a `use-feature.tsx` standard.


## Current Code Issues
<!-- 
Hint: List specific technical debt or design flaws in the current implementation. 
Examples: Code duplication, large functions, magic numbers, poor naming, tight coupling, etc. 
-->
- Hooks don't start with `use` keyword.
- Additionally, `useColorScheme` and `useRefresh` is located inside of `page.tsx` hook which is not allowed, since they access and mutate a complete different data.

## Refactoring Plan
<!-- 
Hint: Describe your step-by-step strategy to improve the code. 
Consider breaking this into logical phases. 
-->

1. Rename all hooks to `use-feature.tsx` naming scheme.
2. Create separate hook files for `useColorScheme` and `useRefresh`.
3. Update import references on all affected files.

## To-do List
<!-- 
Hint: Break the plan into actionable tasks to track progress. Use checkboxes for easy tracking. 
-->

- [ ] useCart
- [ ] useCheckout
- [ ] useFavorite
- [ ] useRefresh
- [ ] useColorScheme

## Acceptance Criteria
<!-- 
Hint: Define clear success conditions. These should be verifiable by tests, peer reviews, or manual inspection. 
-->

- [ ] All react hooks start with `use` keyword.
- [ ] useColorScheme.tsx hook exists and is used
- [ ] useRefresh.tsx hook exists and is used
- [ ] page.tsx is non existent

